### PR TITLE
✨ Add optional setting to show relative file paths 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,24 +63,40 @@ You can copy the contents of the new document and paste it as the prompt of your
 
 ## Configuration
 
-You can customize which file types are included when processing directories. To do this:
+You can customize the extension behavior via **Settings** → **Extensions** → **Copy to LLM**.
 
-1. Open VS Code Settings (File > Preferences > Settings)
-2. Search for "Copy to LLM"
-3. Edit the "Copy to LLM: Extensions" setting to add or remove file extensions
+> ⚠️ **Important:** When copying an entire folder, **only files that match the configured extensions will be included**.
+> Files with extensions not listed in your settings will be skipped and **won't appear in the generated document**.
 
-Default included extensions:
+### Available Settings
+
+| Name                         | JSON Setting                   | Type         | Default                                                | Description                                                                           |
+| ---------------------------- | ------------------------------ | ------------ | ------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| **Extensions**         | `copyToLLM.extensions`       | `string[]` | `[".ts", ".tsx", ".mjs", ".ex", ".heex", ".svelte"]` | File extensions to include when copying directories.                                  |
+| **Use Relative Paths** | `copyToLLM.useRelativePaths` | `boolean`  | `false`                                              | Always accompany the file name with the directory in which it is located within the project. |
+
+### JSON Configuration Example
+
 ```json
-[".ts", ".tsx", ".mjs", ".ex", ".heex", ".svelte"]
+{
+  "copyToLLM.extensions": [
+    ".ts",
+    ".tsx",
+    ".mjs",
+    ".ex",
+    ".heex",
+    ".svelte"
+  ],
+  "copyToLLM.useRelativePaths": true
+}
 ```
 
 ## Example Output
 
-When you use "Copy to LLM" on a file or directory, the output will look similar to this:
-
-```markdown
-src/components/Button.tsx:
-```tsx
+> **With default settings**:
+````
+Button.tsx:
+```
 import React from 'react';
 
 const Button = ({ label, onClick }) => (
@@ -90,12 +106,13 @@ const Button = ({ label, onClick }) => (
 export default Button;
 ```
 
-src/utils/helpers.ts:
-```typescript
+helpers.ts:
+```
 export const capitalizeString = (str: string): string => {
   return str.charAt(0).toUpperCase() + str.slice(1);
 };
 ```
+````
 
 This format makes it easy to understand the structure of your code when sharing it with an LLM.
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                         ".svelte"
                     ],
                     "description": "File extensions to include when copying directories"
+                },
+                "copyToLLM.useRelativePaths": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Accompany the file name with the directory in which it is located within the project"
                 }
             }
         }


### PR DESCRIPTION
# ✨ Add optional setting to show relative file paths

## Description

This pull request introduces a new optional setting to the **Copy to LLM** extension:

### ✅ `copyToLLM.useRelativePaths`
When enabled, file names in the generated Markdown output will always include their relative path from the workspace root (e.g. `src/utils/app.js` instead of just `app.js`).

This helps provide better context when sharing large file structures with LLMs.

It is **disabled** by default in order to avoid disrupting the desired behavior of the actual extension's owner.

---

## What's Included

- 🧠 New logic in `extension.ts` to read and apply the `useRelativePaths` setting
- 🔧 **Updated `package.json`:**
  - Registered the new configuration setting correctly within VS Code settings panel.
- 📝 Updated `README.md`:
  - New table showing both setting name and JSON key
  - Full JSON example for user settings
  - **Bold warning** about ignored files when their extension is not listed in `copyToLLM.extensions`
  - Fix old code encapsulation

---

## New Settings

```json
"copyToLLM.useRelativePaths": {
  "type": "boolean",
  "default": false,
  "description": "Always accompany the file name with the directory in which it is located within the project"
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new setting to control whether file names are shown with relative directory paths when copying files or folders.
- **Documentation**
  - Updated the README to clarify configuration options, highlight file inclusion behavior, and provide improved examples reflecting default settings.
- **Style**
  - Reformatted example output in the documentation for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->