### PR TITLE
✨ Add support for more file extensions in `copyToLLM.extensions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": [
-                        ".ts",
-                        ".tsx",
-                        ".mjs",
-                        ".ex",
-                        ".heex",
-                        ".svelte"
-                    ],
+                    "default": [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".html", ".htm", ".xml", ".ejs", ".pug", ".jade", ".twig", ".erb", ".mustache", ".latte", ".css", ".scss", ".sass", ".less", ".styl", ".json", ".jsonc", ".yaml", ".yml", ".toml", ".ini", ".env", ".md", ".markdown", ".txt", ".ex", ".exs", ".heex", ".leex", ".eex", ".vue", ".svelte", ".astro", ".py", ".rb", ".php", ".java", ".c", ".cpp", ".h", ".hpp", ".go", ".rs", ".swift", ".kt", ".kts", ".dart", ".sql", ".sh", ".bat", ".ps1", ".csv", ".tsv", ".cfg", ".conf", ".properties", ".ics"],
                     "description": "File extensions to include when copying directories"
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,28 @@ async function getFilesByExtensions(dirPath: string): Promise<string[]> {
     const files: string[] = [];
 
     const config = vscode.workspace.getConfiguration('copyToLLM');
-    const extensions = config.get<string[]>('extensions', ['.ts', '.tsx', '.mjs', '.ex', '.heex', '.svelte']);
+    const extensions = config.get<string[]>('extensions', [
+        // JavaScript and TypeScript
+        '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs',
+        // Markup and templating
+        '.html', '.htm', '.xml', '.ejs', '.pug', '.jade', '.twig', '.erb', '.mustache', 'latte',
+        // Stylesheets
+        '.css', '.scss', '.sass', '.less', '.styl',
+        // Configuration and data
+        '.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.env',
+        // Documents and markdown
+        '.md', '.markdown', '.txt',
+        // Elixir and Phoenix templates
+        '.ex', '.exs', '.heex', '.leex', '.eex',
+        // Front-end frameworks and components
+        '.vue', '.svelte', '.astro',
+        // Programming languages and scripts
+        '.py', '.rb', '.php', '.java', '.c', '.cpp', '.h', '.hpp', '.go', '.rs',
+        '.swift', '.kt', '.kts', '.dart', '.sql', '.sh', '.bat', '.ps1',
+        // Other plain-text types
+        '.csv', '.tsv', '.cfg', '.conf'
+    ]);
+
 
     async function traverse(currentPath: string) {
         const entries = await fs.promises.readdir(currentPath, { withFileTypes: true });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,28 +69,7 @@ async function getFilesByExtensions(dirPath: string): Promise<string[]> {
     const files: string[] = [];
 
     const config = vscode.workspace.getConfiguration('copyToLLM');
-    const extensions = config.get<string[]>('extensions', [
-        // JavaScript and TypeScript
-        '.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs',
-        // Markup and templating
-        '.html', '.htm', '.xml', '.ejs', '.pug', '.jade', '.twig', '.erb', '.mustache', 'latte',
-        // Stylesheets
-        '.css', '.scss', '.sass', '.less', '.styl',
-        // Configuration and data
-        '.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.env',
-        // Documents and markdown
-        '.md', '.markdown', '.txt',
-        // Elixir and Phoenix templates
-        '.ex', '.exs', '.heex', '.leex', '.eex',
-        // Front-end frameworks and components
-        '.vue', '.svelte', '.astro',
-        // Programming languages and scripts
-        '.py', '.rb', '.php', '.java', '.c', '.cpp', '.h', '.hpp', '.go', '.rs',
-        '.swift', '.kt', '.kts', '.dart', '.sql', '.sh', '.bat', '.ps1',
-        // Other plain-text types
-        '.csv', '.tsv', '.cfg', '.conf'
-    ]);
-
+    const extensions = config.get<string[]>('extensions', ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs','.html', '.htm', '.xml', '.ejs', '.pug', '.jade', '.twig', '.erb', '.mustache', '.latte', '.css', '.scss', '.sass', '.less', '.styl', '.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.env', '.md', '.markdown', '.txt', '.ex', '.exs', '.heex', '.leex', '.eex', '.vue', '.svelte', '.astro', '.py', '.rb', '.php', '.java', '.c', '.cpp', '.h', '.hpp', '.go', '.rs', '.swift', '.kt', '.kts', '.dart', '.sql', '.sh', '.bat', '.ps1', '.csv', '.tsv', '.cfg', '.conf']);
 
     async function traverse(currentPath: string) {
         const entries = await fs.promises.readdir(currentPath, { withFileTypes: true });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,7 @@ async function getFilesByExtensions(dirPath: string): Promise<string[]> {
     const files: string[] = [];
 
     const config = vscode.workspace.getConfiguration('copyToLLM');
-    const extensions = config.get<string[]>('extensions', ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs','.html', '.htm', '.xml', '.ejs', '.pug', '.jade', '.twig', '.erb', '.mustache', '.latte', '.css', '.scss', '.sass', '.less', '.styl', '.json', '.jsonc', '.yaml', '.yml', '.toml', '.ini', '.env', '.md', '.markdown', '.txt', '.ex', '.exs', '.heex', '.leex', '.eex', '.vue', '.svelte', '.astro', '.py', '.rb', '.php', '.java', '.c', '.cpp', '.h', '.hpp', '.go', '.rs', '.swift', '.kt', '.kts', '.dart', '.sql', '.sh', '.bat', '.ps1', '.csv', '.tsv', '.cfg', '.conf']);
+    const extensions = config.get<string[]>('extensions', [".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".html", ".htm", ".xml", ".ejs", ".pug", ".jade", ".twig", ".erb", ".mustache", ".latte", ".css", ".scss", ".sass", ".less", ".styl", ".json", ".jsonc", ".yaml", ".yml", ".toml", ".ini", ".env", ".md", ".markdown", ".txt", ".ex", ".exs", ".heex", ".leex", ".eex", ".vue", ".svelte", ".astro", ".py", ".rb", ".php", ".java", ".c", ".cpp", ".h", ".hpp", ".go", ".rs", ".swift", ".kt", ".kts", ".dart", ".sql", ".sh", ".bat", ".ps1", ".csv", ".tsv", ".cfg", ".conf", ".properties", ".ics"]);
 
     async function traverse(currentPath: string) {
         const entries = await fs.promises.readdir(currentPath, { withFileTypes: true });


### PR DESCRIPTION
## ✨ Add support for more file extensions in `copyToLLM.extensions`

### Description

This pull request significantly expands the list of file extensions supported by the **Copy to LLM** VS Code extension. Previously, only the following extensions were supported by default:
```ts
const extensions = config.get<string[]>('extensions', ['.ts', '.tsx', '.mjs', '.ex', '.heex', '.svelte']);
```

This caused confusion among users, especially when right-clicking on a folder and selecting "Copy to LLM" — many files were silently excluded, leading some users to believe the extension was broken.

To address this, I added a comprehensive list of commonly used plaintext and code-related file types. With this PR, the new default looks like this:
```ts
const extensions = config.get<string[]>('extensions', [
  ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".html", ".htm", ".xml",
  ".ejs", ".pug", ".jade", ".twig", ".erb", ".mustache", ".latte",
  ".css", ".scss", ".sass", ".less", ".styl",
  ".json", ".jsonc", ".yaml", ".yml", ".toml", ".ini", ".env",
  ".md", ".markdown", ".txt",
  ".ex", ".exs", ".heex", ".leex", ".eex",
  ".vue", ".svelte", ".astro",
  ".py", ".rb", ".php", ".java", ".c", ".cpp", ".h", ".hpp",
  ".go", ".rs", ".swift", ".kt", ".kts", ".dart",
  ".sql", ".sh", ".bat", ".ps1",
  ".csv", ".tsv", ".cfg", ".conf", ".properties", ".ics"
]);
```

### What's Included

- 🧠 Massive default extension list expansion in `extension.ts`
- 🧩 Ensures more real-world projects work "out of the box"
- 🛠 Prevents user confusion when files silently go missing
- 📦 Updated `package.json` to reflect the new default in `copyToLLM.extensions` setting

### Suggested Follow-Up

I strongly suggest updating the `README.md` with the new default extensions list so users are aware of what is supported. Including this in the **Configuration** section would help adoption and avoid misinterpretations.

### Motivation

This change improves user experience, reduces friction, and makes the extension far more usable in real-world scenarios involving multiple file types across various ecosystems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the default set of file types included when copying directories to cover a wider range of programming, markup, configuration, and data file extensions. This allows more diverse files to be processed automatically without additional configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->