### PR TITLE
feat: add ignore patterns for file copying

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
     "name": "copy-to-llm",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "copy-to-llm",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "devDependencies": {
                 "@types/node": "^14.14.37",
                 "@types/vscode": "^1.60.0",
                 "@typescript-eslint/eslint-plugin": "^4.22.0",
                 "@typescript-eslint/parser": "^4.22.0",
                 "eslint": "^7.25.0",
+                "minimatch": "^10.0.3",
                 "typescript": "^4.2.4"
             },
             "engines": {
@@ -152,6 +153,19 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -167,12 +181,48 @@
                 "node": ">=10.10.0"
             }
         },
+        "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/@humanwhocodes/object-schema": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true
+        },
+        "node_modules/@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@isaacs/balanced-match": "^4.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -485,13 +535,15 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -556,7 +608,8 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -778,6 +831,19 @@
             "dev": true,
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/espree": {
@@ -1014,6 +1080,19 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/globals": {
             "version": "13.24.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -1248,15 +1327,19 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+            "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "@isaacs/brace-expansion": "^5.0.0"
             },
             "engines": {
-                "node": "*"
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -115,6 +115,14 @@
           "type": "boolean",
           "default": false,
           "description": "Accompany the file name with the directory in which it is located within the project"
+        },
+        "copyToLLM.ignore": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "An array of glob patterns to ignore when copying files and directories."
         }
       }
     }
@@ -129,11 +137,12 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@types/vscode": "^1.60.0",
     "@types/node": "^14.14.37",
+    "@types/vscode": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "eslint": "^7.25.0",
+    "minimatch": "^10.0.3",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
- Introduced a new configuration option `copyToLLM.ignore` to specify glob patterns for files and directories to ignore during the copy process.
- Updated `getFilesByExtensions` function to utilize the `minimatch` library for matching ignored patterns.
- Enhanced file traversal logic to skip ignored files based on user-defined patterns.

<img width="798" alt="Screenshot 2025-06-22 at 16 34 57" src="https://github.com/user-attachments/assets/5fe24e62-7493-4a20-b677-2930a52ae423" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new setting to allow users to specify glob patterns for files and directories to ignore when copying.
- **Chores**
  - Updated extension dependencies to support the new ignore patterns functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->